### PR TITLE
Fix Skills Level , list by UnAfraid

### DIFF
--- a/L2J_DataPack/dist/game/data/stats/skills/00000-00099.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/00000-00099.xml
@@ -286,7 +286,7 @@
 			</effect>
 		</enchant7pveEffects>
 	</skill>
-	<skill id="7" levels="28" name="Sonic Storm" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2" enchantGroup4="2" enchantGroup5="2" enchantGroup6="2" enchantGroup7="2">
+	<skill id="7" levels="41" name="Sonic Storm" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2" enchantGroup4="2" enchantGroup5="2" enchantGroup6="2" enchantGroup7="2">
 		<table name="#effectPoints"> -114 -117 -119 -121 -124 -126 -129 -131 -133 -136 -138 -140 -142 -144 -146 -148 -150 -152 -154 -156 -157 -159 -160 -162 -163 -164 -166 -167 </table>
 		<table name="#magicLvl"> 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 </table>
 		<table name="#mpConsume"> 55 56 58 59 59 61 62 64 65 67 69 70 71 73 73 75 76 77 79 80 81 83 84 85 86 88 89 90 </table>
@@ -1162,7 +1162,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="35" levels="28" name="Force Storm" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2" enchantGroup4="2" enchantGroup5="2" enchantGroup6="2" enchantGroup7="2">
+	<skill id="35" levels="41" name="Force Storm" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2" enchantGroup4="2" enchantGroup5="2" enchantGroup6="2" enchantGroup7="2">
 		<table name="#effectPoints"> -133 -136 -139 -142 -144 -147 -150 -153 -155 -158 -161 -163 -166 -168 -170 -173 -175 -177 -179 -181 -183 -185 -187 -189 -190 -192 -193 -194 </table>
 		<table name="#magicLvl"> 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 </table>
 		<table name="#mpConsume"> 64 66 67 69 69 71 73 75 76 78 80 82 83 85 85 87 89 90 92 93 95 96 98 99 101 102 104 105 </table>
@@ -1414,7 +1414,7 @@
 			<effect name="ConsumeBody" />
 		</enchant1for>
 	</skill>
-	<skill id="48" levels="37" name="Thunder Storm" enchantGroup1="2" enchantGroup2="2">
+	<skill id="48" levels="46" name="Thunder Storm" enchantGroup1="2" enchantGroup2="2">
 		<table name="#effectPoints"> -92 -94 -97 -99 -102 -104 -107 -109 -112 -114 -117 -119 -121 -124 -126 -129 -131 -133 -136 -138 -140 -142 -144 -146 -148 -150 -152 -154 -156 -157 -159 -160 -162 -163 -164 -166 -167 </table>
 		<table name="#magicLvl"> 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 </table>
 		<table name="#mpConsume"> 52 53 55 55 57 59 60 62 64 66 67 69 71 72 73 75 77 78 80 82 84 85 87 88 90 91 93 94 96 97 99 100 102 103 105 106 107 </table>
@@ -1806,7 +1806,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="69" levels="25" name="Sacrifice" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2" enchantGroup4="2">
+	<skill id="69" levels="34" name="Sacrifice" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2" enchantGroup4="2">
 		<table name="#amount"> 741 762 782 802 822 843 863 882 902 922 941 960 979 997 1015 1033 1050 1067 1083 1099 1115 1129 1144 1157 1170 </table>
 		<table name="#effectPoints"> 494 508 521 535 549 562 575 589 602 615 628 640 653 665 677 689 700 711 722 733 743 753 763 772 780 </table>
 		<table name="#hpConsume"> 988 1015 1042 1069 1096 1123 1150 1176 1203 1229 1254 1280 1305 1329 1353 1377 1400 1422 1444 1465 1486 1506 1525 1543 1560 </table>
@@ -2410,7 +2410,7 @@
 			</effect>
 		</enchant6for>
 	</skill>
-	<skill id="94" levels="2" name="Rage" enchantGroup1="1" enchantGroup2="1">
+	<skill id="94" levels="7" name="Rage" enchantGroup1="1" enchantGroup2="1">
 		<table name="#abnormalLvls"> 1 2 </table>
 		<table name="#accCombat"> 2 4 </table>
 		<table name="#effectPoints"> 235 523 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/00100-00199.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/00100-00199.xml
@@ -978,7 +978,7 @@
 			</effect>
 		</enchant1for>
 	</skill>
-	<skill id="139" levels="3" name="Guts">
+	<skill id="139" levels="9" name="Guts">
 		<!-- Confirmed CT2.5 -->
 		<table name="#abnormalLvls"> 1 2 3 </table>
 		<table name="#effectPoints"> 341 408 495 </table>
@@ -1302,7 +1302,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="172" levels="10" name="Create Item">
+	<skill id="172" levels="14" name="Create Item">
 		<table name="#magicLvl"> 5 20 28 36 43 49 55 62 70 82 </table>
 		<set name="icon" val="icon.skill0172" />
 		<set name="magicLvl" val="#magicLvl" />
@@ -1323,7 +1323,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="176" levels="3" name="Frenzy">
+	<skill id="176" levels="9" name="Frenzy">
 		<!-- Confirmed CT2.5 and Updated to H5 -->
 		<table name="#abnormalLvls"> 1 2 3 </table>
 		<table name="#accCombat"> 2 4 6 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/00200-00299.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/00200-00299.xml
@@ -980,7 +980,7 @@
 			</effect>
 		</enchant2for>
 	</skill>
-	<skill id="239" levels="7" name="Expertise D">
+	<skill id="239" levels="10" name="Expertise D">
 		<table name="#icons"> icon.skill0239 icon.skill0240 icon.skill0241 icon.skill0242 icon.skill0243 icon.skill0243 icon.skill0243 </table>
 		<table name="#magicLvl"> 20 40 52 61 76 80 84 </table>
 		<set name="icon" val="#icons" />
@@ -1074,7 +1074,7 @@
 			<effect name="HeadquarterCreate" />
 		</for>
 	</skill>
-	<skill id="248" levels="5" name="Crystallize">
+	<skill id="248" levels="6" name="Crystallize">
 		<table name="#magicLvl"> 20 40 52 60 70 </table>
 		<set name="icon" val="icon.skill0248" />
 		<set name="magicLvl" val="#magicLvl" />
@@ -1615,7 +1615,7 @@
 			<effect name="Stun" />
 		</enchant1for>
 	</skill>
-	<skill id="261" levels="22" name="Triple Sonic Slash" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2" enchantGroup4="2" enchantGroup5="2" enchantGroup6="2" enchantGroup7="2">
+	<skill id="261" levels="31" name="Triple Sonic Slash" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2" enchantGroup4="2" enchantGroup5="2" enchantGroup6="2" enchantGroup7="2">
 		<table name="#effectPoints"> -598 -609 -620 -631 -641 -651 -661 -671 -680 -690 -699 -708 -716 -724 -732 -739 -746 -753 -759 -765 -771 -776 </table>
 		<table name="#magicLvl"> 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 </table>
 		<table name="#mpConsume"> 103 105 108 110 113 115 118 120 121 123 125 128 130 132 134 136 139 141 143 145 146 148 </table>
@@ -2284,7 +2284,7 @@
 			</effect>
 		</enchant1for>
 	</skill>
-	<skill id="279" levels="5" name="Lightning Strike" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2">
+	<skill id="279" levels="14" name="Lightning Strike" enchantGroup1="2" enchantGroup2="2" enchantGroup3="2">
 		<!-- Confirmed CT2.5 -->
 		<table name="#effectPoints"> -828 -877 -921 -958 -987 </table>
 		<table name="#magicLvl"> 58 62 66 70 74 </table>
@@ -2613,7 +2613,7 @@
 			</effect>
 		</enchant1for>
 	</skill>
-	<skill id="286" levels="3" name="Provoke">
+	<skill id="286" levels="12" name="Provoke">
 		<!-- Confirmed CT2.5 -->
 		<table name="#affectRange"> 500 700 900 </table>
 		<table name="#effectPoints"> -136 -175 -189 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/00300-00399.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/00300-00399.xml
@@ -717,7 +717,7 @@
 			</effect>
 		</enchant2for>
 	</skill>
-	<skill id="320" levels="10" name="Wrath" enchantGroup1="2" enchantGroup2="2">
+	<skill id="320" levels="14" name="Wrath" enchantGroup1="2" enchantGroup2="2">
 		<table name="#effectPoints"> -307 -311 -314 -317 -320 -323 -326 -328 -331 -333 </table>
 		<table name="#magicLvl"> 65 66 67 68 69 70 71 72 73 74 </table>
 		<table name="#mpConsume"> 66 67 68 69 70 71 72 73 74 75 </table>
@@ -2426,7 +2426,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="367" levels="1" name="Dance of Medusa" enchantGroup1="5" enchantGroup2="5">
+	<skill id="367" levels="8" name="Dance of Medusa" enchantGroup1="5" enchantGroup2="5">
 		<!-- Confirmed CT2.5 and Updated to H5 -->
 		<table name="#ench1ActivateRates"> 42 45 48 50 53 56 58 61 64 66 69 72 74 77 80 </table>
 		<table name="#ench2AbnormalTimes"> 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/00400-00499.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/00400-00499.xml
@@ -268,7 +268,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="404" levels="5" name="Mass Shackling" enchantGroup1="1" enchantGroup2="1">
+	<skill id="404" levels="14" name="Mass Shackling" enchantGroup1="1" enchantGroup2="1">
 		<table name="#effectPoints"> -1098 -1163 -1221 -1270 -1309 </table>
 		<table name="#magicLvl"> 58 62 66 70 74 </table>
 		<table name="#mpConsume"> 40 43 46 59 51 </table>
@@ -591,7 +591,7 @@
 			</effect>
 		</selfEffects>
 	</skill>
-	<skill id="410" levels="3" name="Mortal Strike" enchantGroup1="2" enchantGroup2="2">
+	<skill id="410" levels="8" name="Mortal Strike" enchantGroup1="2" enchantGroup2="2">
 		<!-- NOTE: This skill increases "Blow Rate" and description in client says "Critical Rate" but is client typo, so please don't change this skill -->
 		<table name="#abnormalLvls"> 1 2 3 </table>
 		<table name="#blowRate"> 1.1 1.15 1.2 </table>
@@ -1239,7 +1239,7 @@
 			</effect>
 		</enchant1for>
 	</skill>
-	<skill id="430" levels="1" name="Master of Combat" enchantGroup1="5" enchantGroup2="5">
+	<skill id="430" levels="8" name="Master of Combat" enchantGroup1="5" enchantGroup2="5">
 		<!-- Confirmed CT2.5 -->
 		<table name="#enchMagicLvl"> 81 81 81 82 82 82 83 83 83 84 84 84 85 85 85 </table>
 		<table name="#enchPAtk"> 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 </table>
@@ -1485,7 +1485,7 @@
 			</effect>
 		</enchant1for>
 	</skill>
-	<skill id="437" levels="1" name="Song of Silence" enchantGroup1="5" enchantGroup2="5">
+	<skill id="437" levels="7" name="Song of Silence" enchantGroup1="5" enchantGroup2="5">
 		<!-- Confirmed CT2.5 -->
 		<table name="#ench1ActivateRates"> 62 64 66 68 70 72 74 76 78 80 82 84 86 88 90 </table>
 		<table name="#ench1EffectPoints"> -154 -159 -165 -171 -177 -183 -189 -196 -202 -209 -215 -222 -229 -236 -243 </table>
@@ -2708,7 +2708,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="483" levels="2" name="Sword Shield" enchantGroup1="1" enchantGroup2="1">
+	<skill id="483" levels="8" name="Sword Shield" enchantGroup1="1" enchantGroup2="1">
 		<!-- Confirmed CT2.5 -->
 		<table name="#abnormalLvls"> 1 2 </table>
 		<table name="#effectPoints"> 204 438 </table>
@@ -2776,7 +2776,7 @@
 			<effect name="EnemyCharge" />
 		</for>
 	</skill>
-	<skill id="485" levels="7" name="Disarm" enchantGroup1="1" enchantGroup2="1">
+	<skill id="485" levels="16" name="Disarm" enchantGroup1="1" enchantGroup2="1">
 		<!-- Confirmed CT2.5 -->
 		<table name="#effectPoints"> -341 -408 -467 -523 -582 -624 -655 </table>
 		<table name="#magicLvl"> 36 43 49 55 62 68 74 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/00700-00799.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/00700-00799.xml
@@ -2489,7 +2489,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="793" levels="1" name="Rush Impact" enchantGroup1="6" enchantGroup2="6" enchantGroup3="6" enchantGroup4="6" enchantGroup5="6" enchantGroup6="6" enchantGroup7="6" enchantGroup8="6">
+	<skill id="793" levels="5" name="Rush Impact" enchantGroup1="6" enchantGroup2="6" enchantGroup3="6" enchantGroup4="6" enchantGroup5="6" enchantGroup6="6" enchantGroup7="6" enchantGroup8="6">
 		<!-- Confirmed CT2.5 -->
 		<table name="#ench1Power"> 4071 4102 4133 4164 4195 4226 4257 4289 4320 4351 4382 4413 4444 4475 4507 </table>
 		<table name="#ench2Cost"> 80 78 76 74 72 70 68 66 64 62 59 57 55 53 51 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/01000-01099.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/01000-01099.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <list xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../xsd/skills.xsd">
-	<skill id="1001" levels="10" name="Soul Cry" enchantGroup1="1">
+	<skill id="1001" levels="15" name="Soul Cry" enchantGroup1="1">
 		<!-- Confirmed CT2.5 -->
 		<table name="#magicLvl"> 1 14 25 35 40 48 56 60 66 72 </table>
 		<table name="#mdot"> 0 0 1 2 2 2 3 3 4 4 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/01100-01199.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/01100-01199.xml
@@ -403,7 +403,7 @@
 			</effect>
 		</enchant1for>
 	</skill>
-	<skill id="1129" levels="7" name="Summon Reanimated Man" enchantGroup1="1">
+	<skill id="1129" levels="13" name="Summon Reanimated Man" enchantGroup1="1">
 		<table name="#itemConsumeCount"> 11 13 6 9 9 6 9 </table>
 		<table name="#itemConsumeCountOT"> 0 0 1 1 1 2 2 </table>
 		<table name="#itemConsumeSteps"> 0 0 14 14 14 14 14 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/01200-01299.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/01200-01299.xml
@@ -1457,7 +1457,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="1244" levels="4" name="Freezing Flame">
+	<skill id="1244" levels="10" name="Freezing Flame">
 		<table name="#abnormalLvls"> 5 6 7 8 </table>
 		<table name="#dot"> 102 125 144 157 </table>
 		<table name="#effectPoints"> -379 -495 -597 -646 </table>
@@ -2181,7 +2181,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="1262" levels="5" name="Transfer Pain" enchantGroup1="1">
+	<skill id="1262" levels="10" name="Transfer Pain" enchantGroup1="1">
 		<table name="#magicLvl"> 40 48 56 58 70 </table>
 		<table name="#mpInitialConsume"> 7 9 11 12 13 </table>
 		<table name="#power"> 10 20 30 40 50 </table>
@@ -2208,7 +2208,7 @@
 			</effect>
 		</enchant1for>
 	</skill>
-	<skill id="1263" levels="13" name="Curse Gloom" enchantGroup1="1" enchantGroup2="1">
+	<skill id="1263" levels="21" name="Curse Gloom" enchantGroup1="1" enchantGroup2="1">
 		<table name="#effectPoints"> -209 -229 -248 -266 -275 -283 -291 -299 -306 -312 -318 -323 -328 </table>
 		<table name="#magicLvl"> 44 48 52 56 58 60 62 64 66 68 70 72 74 </table>
 		<table name="#mpConsume"> 31 35 38 41 43 44 46 48 49 51 52 53 55 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/01300-01399.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/01300-01399.xml
@@ -890,7 +890,7 @@
 			</effect>
 		</enchant1for>
 	</skill>
-	<skill id="1334" levels="7" name="Summon Cursed Man" enchantGroup1="1">
+	<skill id="1334" levels="13" name="Summon Cursed Man" enchantGroup1="1">
 		<table name="#itemConsumeCount"> 3 5 12 1 2 3 4 </table>
 		<table name="#itemConsumeCountOT"> 1 1 1 2 2 2 2 </table>
 		<table name="#magicLvl"> 56 60 64 68 70 72 74 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/01400-01499.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/01400-01499.xml
@@ -234,7 +234,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="1405" levels="4" name="Divine Inspiration">
+	<skill id="1405" levels="6" name="Divine Inspiration">
 		<!-- Confirmed CT2.5 -->
 		<table name="#magicLvl"> 52 61 76 76 </table>
 		<table name="#slots"> 1 2 3 4 </table>
@@ -2072,7 +2072,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="1457" levels="1" name="Empowering Echo" enchantGroup1="5" enchantGroup2="5">
+	<skill id="1457" levels="2" name="Empowering Echo" enchantGroup1="5" enchantGroup2="5">
 		<table name="#ench1AbnormalTimes"> 1240 1280 1320 1360 1400 1440 1480 1520 1560 1600 1640 1680 1720 1760 1800 </table>
 		<table name="#ench2mpConsume"> 140 135 130 125 120 115 110 106 101 96 91 86 81 76 72 </table>
 		<set name="abnormalLvl" val="1" />
@@ -2231,7 +2231,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="1462" levels="1" name="Seal of Blockade" enchantGroup1="6" enchantGroup2="6">
+	<skill id="1462" levels="7" name="Seal of Blockade" enchantGroup1="6" enchantGroup2="6">
 		<!-- Confirmed CT2.5 -->
 		<table name="#ench1ActivateRates"> 82 83 84 86 87 88 90 91 92 94 95 96 97 99 100 </table>
 		<table name="#ench2MpConsume"> 84 81 78 75 72 69 66 63 61 58 55 52 49 46 43 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/01500-01599.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/01500-01599.xml
@@ -483,7 +483,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="1514" levels="1" name="Soul Barrier" enchantGroup1="1" enchantGroup2="1">
+	<skill id="1514" levels="7" name="Soul Barrier" enchantGroup1="1" enchantGroup2="1">
 		<!-- Confirmed CT2.5 and Updated to H5 -->
 		<table name="#ench1AbnormalTimes"> 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 </table>
 		<table name="#ench2pDef"> 10 20 30 40 50 60 70 80 90 100 110 120 130 140 150 160 170 180 190 200 210 220 230 240 250 260 270 280 290 300 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/02200-02299.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/02200-02299.xml
@@ -1901,7 +1901,7 @@
 			<effect name="Recovery" />
 		</for>
 	</skill>
-	<skill id="2287" levels="6" name="Elixir of Life (No-grade)">
+	<skill id="2287" levels="7" name="Elixir of Life (No-grade)">
 		<!-- Confirmed CT2.5 -->
 		<table name="#amount"> 250 650 1100 1500 1900 2300 </table>
 		<table name="#levelRange"> 1;19 20;39 40;51 52;60 61;75 76;85 </table>
@@ -1919,7 +1919,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="2288" levels="6" name="Elixir of Mind (No-grade)">
+	<skill id="2288" levels="7" name="Elixir of Mind (No-grade)">
 		<!-- Confirmed CT2.5 -->
 		<table name="#amount"> 60 140 220 290 360 420 </table>
 		<table name="#levelRange"> 1;19 20;39 40;51 52;60 61;75 76;85 </table>
@@ -1937,7 +1937,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="2289" levels="6" name="Elixir of CP (No-grade)">
+	<skill id="2289" levels="7" name="Elixir of CP (No-grade)">
 		<!-- Confirmed CT2.5 -->
 		<table name="#amount"> 150 350 600 800 1000 1200 </table>
 		<table name="#levelRange"> 1;19 20;39 40;51 52;60 61;75 76;85 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/02800-02899.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/02800-02899.xml
@@ -1390,7 +1390,7 @@
 		<set name="rideState" val="NONE;STRIDER;WYVERN;WOLF" />
 		<set name="targetType" val="NONE" />
 	</skill>
-	<skill id="2860" levels="6" name="Superior Elixir of Life (No-grade)">
+	<skill id="2860" levels="7" name="Superior Elixir of Life (No-grade)">
 		<!-- Confirmed CT2.5 -->
 		<table name="#amount"> 500 1300 2200 3000 3800 4600 </table>
 		<table name="#levelRange"> 1;19 20;39 40;51 52;60 61;75 76;85 </table>
@@ -1411,7 +1411,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="2861" levels="6" name="Superior Elixir of Mind (No-grade)">
+	<skill id="2861" levels="7" name="Superior Elixir of Mind (No-grade)">
 		<!-- Confirmed CT2.5 -->
 		<table name="#amount"> 120 280 440 580 720 840 </table>
 		<table name="#levelRange"> 1;19 20;39 40;51 52;60 61;75 76;85 </table>
@@ -1432,7 +1432,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="2862" levels="6" name="Superior Elixir of CP (No-grade)">
+	<skill id="2862" levels="7" name="Superior Elixir of CP (No-grade)">
 		<!-- Confirmed CT2.5 -->
 		<table name="#amount"> 300 700 1200 1600 2000 2400 </table>
 		<table name="#levelRange"> 1;19 20;39 40;51 52;60 61;75 76;85 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/04000-04099.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/04000-04099.xml
@@ -845,7 +845,7 @@
 			<effect name="Sleep" />
 		</for>
 	</skill>
-	<skill id="4047" levels="12" name="Hold">
+	<skill id="4047" levels="13" name="Hold">
 		<!-- Freya retail confirmed -->
 		<table name="#magicLvl"> 10 20 30 40 50 60 70 75 80 85 90 95 </table>
 		<table name="#mpConsume"> 10 16 21 28 36 44 52 55 58 60 61 62 </table>
@@ -930,7 +930,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="4051" levels="20" name="Cubic Heal">
+	<skill id="4051" levels="17" name="Cubic Heal">
 		<!-- Cubic Skill -->
 		<!-- Confirmed CT2.5 -->
 		<!-- Levels 17, 18 and 19 doesn't exist in client. -->

--- a/L2J_DataPack/dist/game/data/stats/skills/04200-04299.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/04200-04299.xml
@@ -1462,7 +1462,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="4271" levels="8" name="Momentum">
+	<skill id="4271" levels="50" name="Momentum">
 		<!-- Freya retail confirmed -->
 		<table name="#icons"> icon.skill4271_1 icon.skill4271_2 icon.skill4271_3 icon.skill4271_4 icon.skill4271_5 icon.skill4271_6 icon.skill4271_7 icon.skill4271_8 </table>
 		<set name="icon" val="#icons" />

--- a/L2J_DataPack/dist/game/data/stats/skills/04400-04499.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/04400-04499.xml
@@ -271,7 +271,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="4416" levels="25" name="Undead">
+	<skill id="4416" levels="26" name="Undead">
 		<!-- Confirmed CT2.5 -->
 		<table name="#icons"> icon.skill4290 icon.skill4291 icon.skill4292 icon.skill4293 icon.skill4294 icon.skill4295 icon.skill4296 icon.skill4297 icon.skill4298 icon.skill4299 icon.skill4300 icon.skill4301 icon.skill4302 icon.skill4416_human icon.skill4416_elf icon.skill4416_darkelf icon.skill4416_orc icon.skill4416_dwarf icon.skill4416_etc icon.skill4416_none icon.skill4416_siegeweapon icon.skill4416_castleguard icon.skill4416_mercenary icon.skill4416_none icon.skill4296 </table>
 		<table name="#pDefAnimals"> 0 0 0 -15 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/04700-04799.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/04700-04799.xml
@@ -238,7 +238,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="4708" levels="10" name="Cursed Strike">
+	<skill id="4708" levels="14" name="Cursed Strike">
 		<table name="#effectPoints"> -279 -296 -311 -323 -328 -333 -337 -340 -341 -342 </table>
 		<table name="#magicLvl"> 58 62 66 70 72 74 76 78 79 80 </table>
 		<table name="#mpConsume"> 58 62 67 71 73 75 77 78 79 80 </table>
@@ -269,7 +269,7 @@
 			<effect name="Stun" />
 		</for>
 	</skill>
-	<skill id="4709" levels="10" name="Cursed Blow">
+	<skill id="4709" levels="14" name="Cursed Blow">
 		<table name="#effectPoints"> -279 -296 -311 -323 -328 -333 -337 -340 -341 -342 </table>
 		<table name="#magicLvl"> 58 62 66 70 72 74 76 78 79 80 </table>
 		<table name="#mpConsume"> 58 62 67 71 73 75 77 78 79 80 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/05100-05199.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/05100-05199.xml
@@ -1013,7 +1013,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5151" levels="10" name="Mana Gain">
+	<skill id="5151" levels="15" name="Mana Gain">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#magicLvl"> 46 49 52 55 58 61 64 67 70 75 </table>
@@ -1078,7 +1078,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5154" levels="10" name="Might">
+	<skill id="5154" levels="15" name="Might">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#magicLvl"> 46 49 52 55 58 61 64 67 70 75 </table>
@@ -1101,7 +1101,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5156" levels="10" name="Empower">
+	<skill id="5156" levels="15" name="Empower">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#magicLvl"> 46 49 52 55 58 61 64 67 70 75 </table>
@@ -1147,7 +1147,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5158" levels="10" name="Shield">
+	<skill id="5158" levels="15" name="Shield">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#magicLvl"> 46 49 52 55 58 61 64 67 70 75 </table>
@@ -1170,7 +1170,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5159" levels="10" name="Magic Barrier">
+	<skill id="5159" levels="15" name="Magic Barrier">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#magicLvl"> 46 49 52 55 58 61 64 67 70 75 </table>
@@ -1221,7 +1221,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5161" levels="10" name="Agility">
+	<skill id="5161" levels="15" name="Agility">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#magicLvl"> 46 49 52 55 58 61 64 67 70 75 </table>
@@ -1244,7 +1244,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5162" levels="10" name="Guidance">
+	<skill id="5162" levels="15" name="Guidance">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#accCombat"> 1 1 1 2 2 2 3 3 3 4 </table>
@@ -1313,7 +1313,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5165" levels="10" name="Charm">
+	<skill id="5165" levels="15" name="Charm">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#magicLvl"> 46 49 52 55 58 61 64 67 70 75 </table>
@@ -1336,7 +1336,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5166" levels="10" name="Decrease Speed">
+	<skill id="5166" levels="15" name="Decrease Speed">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#magicLvl"> 46 49 52 55 58 61 64 67 70 75 </table>
@@ -1363,7 +1363,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5167" levels="10" name="Winter">
+	<skill id="5167" levels="15" name="Winter">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#magicLvl"> 46 49 52 55 58 61 64 67 70 75 </table>
@@ -1560,7 +1560,7 @@
 			<!-- FIXME: We need an instant effect that will work only vs monsters and fear them with 40% chance for 20 seconds here -->
 		</for>
 	</skill>
-	<skill id="5174" levels="10" name="Poison">
+	<skill id="5174" levels="15" name="Poison">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#abnormalLvls"> 5 5 6 6 6 7 7 7 8 8 </table>
@@ -1591,7 +1591,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5175" levels="10" name="Bleed">
+	<skill id="5175" levels="15" name="Bleed">
 		<!-- Confirmed CT2.5 -->
 		<!-- Augmentation Skill (Trigger) -->
 		<table name="#abnormalLvls"> 5 5 6 6 6 7 7 7 8 8 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/05600-05699.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/05600-05699.xml
@@ -726,7 +726,7 @@
 			</effect>
 		</for>
 	</skill>
-	<skill id="5646" levels="2" name="Seraphim the Unicorn - Wild Magic">
+	<skill id="5646" levels="3" name="Seraphim the Unicorn - Wild Magic">
 		<!-- Confirmed CT2.5 -->
 		<!-- 3 lvl not_used, don't add it on skill -->
 		<table name="#abnormalLvls"> 1 2 3 </table>

--- a/L2J_DataPack/dist/game/data/stats/skills/05800-05899.xml
+++ b/L2J_DataPack/dist/game/data/stats/skills/05800-05899.xml
@@ -1408,7 +1408,7 @@
 			<effect name="Disarm" />
 		</for>
 	</skill>
-	<skill id="5885" levels="2" name="Weakened Sweep">
+	<skill id="5885" levels="1" name="Weakened Sweep">
 		<!-- Confirmed CT2.5 -->
 		<!-- NOTE: lvl 2 has wrong Id in client -->
 		<table name="#icons"> icon.skill0100 icon.skill0000 </table>


### PR DESCRIPTION
skill id: 7 name: Sonic Storm has different level count: previous: 28
new: 41
skill id: 35 name: Force Storm has different level count: previous: 28
new: 41
skill id: 48 name: Thunder Storm has different level count: previous: 37
new: 46
skill id: 69 name: Sacrifice has different level count: previous: 25
new: 34
skill id: 94 name: Rage has different level count: previous: 2 new: 7
skill id: 139 name: Guts has different level count: previous: 3 new: 9
skill id: 172 name: Create Item has different level count: previous: 10
new: 14
skill id: 176 name: Frenzy has different level count: previous: 3 new: 9
skill id: 239 name: Expertise D has different level count: previous: 7
new: 10
skill id: 248 name: Crystallize has different level count: previous: 5
new: 6
skill id: 261 name: Triple Sonic Slash has different level count:
previous: 22 new: 31
skill id: 279 name: Lightning Strike has different level count:
previous: 5 new: 14
skill id: 286 name: Provoke has different level count: previous: 3 new:
12
skill id: 320 name: Wrath has different level count: previous: 10 new:
14
skill id: 367 name: Dance of Medusa has different level count: previous:
1 new: 8
skill id: 404 name: Mass Shackling has different level count: previous:
5 new: 14
skill id: 410 name: Mortal Strike has different level count: previous: 3
new: 8
skill id: 430 name: Master of Combat has different level count:
previous: 1 new: 8
skill id: 437 name: Song of Silence has different level count: previous:
1 new: 7
skill id: 483 name: Sword Shield has different level count: previous: 2
new: 8
skill id: 485 name: Disarm has different level count: previous: 7 new:
16
skill id: 793 name: Rush Impact has different level count: previous: 1
new: 5
skill id: 1001 name: Soul Cry has different level count: previous: 10
new: 15
skill id: 1129 name: Summon Reanimated Man has different level count:
previous: 7 new: 13
skill id: 1244 name: Freezing Flame has different level count: previous:
4 new: 10
skill id: 1262 name: Transfer Pain has different level count: previous:
5 new: 10
skill id: 1263 name: Curse Gloom has different level count: previous: 13
new: 21
skill id: 1334 name: Summon Cursed Man has different level count:
previous: 7 new: 13
skill id: 1405 name: Divine Inspiration has different level count:
previous: 4 new: 6
skill id: 1457 name: Empowering Echo has different level count:
previous: 1 new: 2
skill id: 1462 name: Seal of Blockade has different level count:
previous: 1 new: 7
skill id: 1514 name: Soul Barrier has different level count: previous: 1
new: 7
skill id: 2287 name: Elixir of Life (No-grade) has different level
count: previous: 6 new: 7
skill id: 2288 name: Elixir of Mind (No-grade) has different level
count: previous: 6 new: 7
skill id: 2289 name: Elixir of CP (No-grade) has different level count:
previous: 6 new: 7
skill id: 2860 name: Superior Elixir of Life (No-grade) has different
level count: previous: 6 new: 7
skill id: 2861 name: Superior Elixir of Mind (No-grade) has different
level count: previous: 6 new: 7
skill id: 2862 name: Superior Elixir of CP (No-grade) has different
level count: previous: 6 new: 7
skill id: 4047 name: Hold has different level count: previous: 12 new:
13
skill id: 4051 name: Cubic Heal has different level count: previous: 20
new: 17
skill id: 4271 name: Momentum has different level count: previous: 8
new: 50
skill id: 4416 name: Undead has different level count: previous: 25 new:
26
skill id: 4708 name: Cursed Strike has different level count: previous:
10 new: 14
skill id: 4709 name: Cursed Blow has different level count: previous: 10
new: 14
skill id: 5151 name: Mana Gain has different level count: previous: 10
new: 15
skill id: 5154 name: Might has different level count: previous: 10 new:
15
skill id: 5156 name: Empower has different level count: previous: 10
new: 15
skill id: 5158 name: Shield has different level count: previous: 10 new:
15
skill id: 5159 name: Magic Barrier has different level count: previous:
10 new: 15
skill id: 5161 name: Agility has different level count: previous: 10
new: 15
skill id: 5162 name: Guidance has different level count: previous: 10
new: 15
skill id: 5165 name: Charm has different level count: previous: 10 new:
15
skill id: 5166 name: Decrease Speed has different level count: previous:
10 new: 15
skill id: 5167 name: Winter has different level count: previous: 10 new:
15
skill id: 5174 name: Poison has different level count: previous: 10 new:
15
skill id: 5175 name: Bleed has different level count: previous: 10 new:
15
skill id: 5646 name: Seraphim the Unicorn - Wild Magic has different
level count: previous: 2 new: 3
skill id: 5885 name: Weakened Sweep has different level count: previous:
2 new: 1