### PR TITLE
Updating Trandon AI

### DIFF
--- a/L2J_DataPack/dist/game/data/scripts/ai/npc/Trandon/Trandon.java
+++ b/L2J_DataPack/dist/game/data/scripts/ai/npc/Trandon/Trandon.java
@@ -224,12 +224,6 @@ public final class Trandon extends AbstractNpcAI
 				{
 					htmltext = "33490-25.html";
 				}
-				else if ((player.getLevel() < DUAL_SKILL_LEVELS[0]) || (player.getStat().getBaseLevel() < DUAL_SKILL_LEVELS[0])) // Dual or main class level is lower than 85
-				{
-					// TODO: What happens here?
-					player.sendMessage("Your level is too low.");
-					htmltext = null;
-				}
 				break;
 			}
 			case "dualCertify":
@@ -335,7 +329,6 @@ public final class Trandon extends AbstractNpcAI
 			giveSkills(player, "DualSkillList");
 		}
 		giveSkills(player, "SubSkillList");
-		player.sendSkillList();
 	}
 	
 	@RegisterEvent(EventType.ON_PLAYER_LOGIN)


### PR DESCRIPTION
- Removed custom level check for dual certificates
- Removed sending skill list on subclass change (unnecessary since
ExSubjobInfo update)