### PR TITLE
Fix One Target Handler

### DIFF
--- a/L2J_DataPack/dist/game/data/scripts/handlers/targethandlers/One.java
+++ b/L2J_DataPack/dist/game/data/scripts/handlers/targethandlers/One.java
@@ -34,7 +34,7 @@ public class One implements ITargetTypeHandler
 	public L2Object[] getTargetList(Skill skill, L2Character activeChar, boolean onlyFirst, L2Character target)
 	{
 		// Check for null target or any other invalid target
-		if ((target == null) || target.isDead() || ((target == activeChar) && skill.isBad()))
+		if ((target == null) || target.isDead() || ((target == activeChar) && skill.isBad()) || (activeChar.isMonster() && target.isPlayable() && !skill.isBad()))
 		{
 			activeChar.sendPacket(SystemMessageId.TARGET_IS_INCORRECT);
 			return EMPTY_TARGET_LIST;


### PR DESCRIPTION
## Summary

Fix One Target Handler to avoiding monsters buff a player.

Note: probably a core-side solution it would be better.

## Test plan

1) Create a player lvl 80 with full armor and jewels +65535.
2) Go to Golkonda and strikes it one time.
3) Let Golkonda attacks you to see if it buffs you with Boss Might. You can remove its buffs to force to cast the skill again. Obviously, with this fix it shouldn't happens.

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=31349