### PR TITLE
DisciplesNecropolisPast instance fixed

### DIFF
--- a/L2J_DataPack/dist/game/data/scripts/instances/DisciplesNecropolisPast/DisciplesNecropolisPast.java
+++ b/L2J_DataPack/dist/game/data/scripts/instances/DisciplesNecropolisPast/DisciplesNecropolisPast.java
@@ -150,6 +150,7 @@ public final class DisciplesNecropolisPast extends AbstractInstance
 	
 	private synchronized void checkDoors(L2Npc npc, DNPWorld world)
 	{
+		world.countKill++;
 		switch (world.countKill)
 		{
 			case 4:
@@ -380,7 +381,6 @@ public final class DisciplesNecropolisPast extends AbstractInstance
 		if (tmpworld instanceof DNPWorld)
 		{
 			final DNPWorld world = (DNPWorld) tmpworld;
-			world.countKill++;
 			checkDoors(npc, world);
 		}
 		


### PR DESCRIPTION
## Summary

Multithread problem when you kill mobs at the same time. The countKill var sets the same value twice and the door never opens.

## Test plan

1) Take 'Seven Signs - Seal of the Emperor' quest and enter into DisciplinesNecropolis instance.
2) Use the Sacred Sword of  Einhasad's skill to kill a few mobs at the same time. It should always open the doors when you killed all mobs in the room.
3) Repeat the test several times, remember, it's a multithread problem :dart: 

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=31032

Thank you HanNaGamSa for the report!