### PR TITLE
HallOfSuffering html paths fixed

### DIFF
--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-00.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-00.htm
@@ -3,5 +3,5 @@ I'm very impressed.<br>
 No one has ever broken through this fast to the Hall of Suffering. Extraordinary! In recognition of your achievement, I will give you a <font color="LEVEL">Jeweled Battle Supply</font>.<br>
 It is granted only to those who achieve an especially impressive feat in battle.<br>
 Your leader may receive it on your behalf.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-01.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-01.htm
@@ -2,5 +2,5 @@
 Unknown Text!<br>
 The reward is <font color="LEVEL">Mother-of-Pearl Ornamented Duel Supplies</font>.<br>
 I'll grant this reward to the leader who represents all of you.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-02.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-02.htm
@@ -2,5 +2,5 @@
 Unknown Text!<br>
 The reward is <font color="LEVEL">Gold-Ornamented Duel Supplies</font>.<br>
 I'll grant this reward to the leader who represents all of you.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-03.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-03.htm
@@ -2,5 +2,5 @@
 Unknown Text!<br>
 The reward is <font color="LEVEL">Silver-Ornamented Duel Supplies</font>.<br>
 I'll grant this reward to the leader who represents all of you.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-04.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-04.htm
@@ -2,5 +2,5 @@
 Unknown Text!<br>
 The reward is <font color="LEVEL">Bronze-Ornamented Duel Supplies</font>.<br>
 I'll grant this reward to the leader who represents all of you.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-05.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-05.htm
@@ -2,5 +2,5 @@
 Unknown Text!<br>
 The reward is <font color="LEVEL">Non-Ornamented Duel Supplies</font>.<br>
 I'll grant this reward to the leader who represents all of you.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-06.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-06.htm
@@ -2,5 +2,5 @@
 Unknown Text!<br>
 The reward is <font color="LEVEL">Weak-Looking Duel Supplies</font>.<br>
 I'll grant this reward to the leader who represents all of you.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-07.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-07.htm
@@ -2,5 +2,5 @@
 Unknown Text!<br>
 The reward is <font color="LEVEL">Sad-Looking Duel Supplies</font>.<br>
 I'll grant this reward to the leader who represents all of you.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-08.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-08.htm
@@ -2,5 +2,5 @@
 Unknown Text!<br>
 The reward is <font color="LEVEL">Poor-Looking Duel Supplies</font>.<br>
 I'll grant this reward to the leader who represents all of you.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-09.htm
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-09.htm
@@ -2,5 +2,5 @@
 I'm very disappointed.<br>
 If I had known your skills were this embarrasingly poor, I would not have assigned you this mission. You're lucky to still be alive! Still, a promise is a promise, so I will give you this <font color="LEVEL">Worthless Battle Supply</font>.<br>
 I'll grant this reward to the leader who represents all of you.<br>
-<a action="bypass -h npc_%objectId%_Quest SeedOfInfinity">Receive the supply.</a>
+<a action="bypass -h npc_%objectId%_Quest HallOfSuffering">Receive the supply.</a>
 </body></html>

--- a/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/HallOfSuffering.java
+++ b/L2J_DataPack/dist/game/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/HallOfSuffering.java
@@ -188,7 +188,7 @@ public final class HallOfSuffering extends AbstractNpcAI
 	
 	public HallOfSuffering()
 	{
-		super(HallOfSuffering.class.getSimpleName(), "gracia/instances/SeedOfInfinity/HallOfSuffering");
+		super(HallOfSuffering.class.getSimpleName(), "gracia/instances/SeedOfInfinity");
 		addStartNpc(MOUTHOFEKIMUS, TEPIOS);
 		addTalkId(MOUTHOFEKIMUS, TEPIOS);
 		addFirstTalkId(TEPIOS);
@@ -449,7 +449,7 @@ public final class HallOfSuffering extends AbstractNpcAI
 	
 	private String getPtLeaderText(L2PcInstance player, HSWorld world)
 	{
-		String htmltext = HtmCache.getInstance().getHtm(player.getHtmlPrefix(), "/data/scripts/instances/SeedOfInfinity/HallOfSuffering/32530-10.htm");
+		String htmltext = HtmCache.getInstance().getHtm(player.getHtmlPrefix(), "/data/scripts/gracia/instances/SeedOfInfinity/HallOfSuffering/32530-10.htm");
 		htmltext = htmltext.replaceAll("%ptLeader%", String.valueOf(world.ptLeaderName));
 		return htmltext;
 	}


### PR DESCRIPTION
## Summary

Problem: wrong html path in HallOfSuffering instance causes missing html to show

## Test plan

1) Go to Infinity Airship, enter in the seed
2) Do a party with two players
3) Talk with Mouth of Ekimus and enter into the instance
4) Finish it and talk with Epidos at the end. You should see the html and it should give you the reward

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=31263

Reported by: dragon01

Thank you!