### PR TITLE
Fix: minor typo on multisell

### DIFF
--- a/dist/game/data/multisell/311262506.xml
+++ b/dist/game/data/multisell/311262506.xml
@@ -628,7 +628,7 @@
 		<!-- Sealed Majestic Boots -->
 		<ingredient count="1" id="11461" />
 		<!-- Adena -->
-		<ingredient count="13200" id="57" />
+		<ingredient count="132000" id="57" />
 		<!-- Majestic Boots - Heavy Armor -->
 		<production count="1" id="11453" />
 	</item>


### PR DESCRIPTION
## Summary

Fix: minor typo on multisell when you try to exchange Sealed Majestic Boots for Majestic Boots - Heavy Armor.

## Report

http://www.l2jserver.com/forum/viewtopic.php?f=77&t=31558

Reported by sahar